### PR TITLE
Version bump (in upstream only, see description)

### DIFF
--- a/plugins.yaml
+++ b/plugins.yaml
@@ -32,9 +32,9 @@ plugins:
         archive_path: 'GOG2_Fanatical_Plugin-7e5989e633fed91e4ca6b5029c8c6873b05bb8b7/src/'
     humble:
         default: true
-        version: '0.9.5'
+        version: '0.10.0'
         guid: 'f0ca3d80-a432-4d35-a9e3-60f27161ac3a'
-        url: 'https://github.com/FriendsOfGalaxy/galaxy-integration-humble/releases/download/0.9.5/windows.zip'
+        url: 'https://github.com/UncleGoogle/galaxy-integration-humblebundle/releases/download/v${version}/humble_v${version}_win.zip'
     indiegala:
         version: '0.1.0'
         guid: 'a1a85742-f3e0-42ae-bde9-64ab7d0321cf'


### PR DESCRIPTION
First of a few changes moving from FriendsOfGalaxy repos to their upstreams (which also will more accurately reflect links in the Mixaill/awesome-gog-galaxy "Github-official" list).  FoG repositories are no longer updating, and haven't been since early January.  See https://github.com/gogcom/galaxy-integrations-python-api/issues/194  This has broken a number of plugins, including this one.